### PR TITLE
Fix: don't add slash between url and query parameters

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -63,7 +63,7 @@
   "Send QUERY to the server at `graphql-url' and return the
 response from the server."
   (let ((url-request-method "POST")
-        (url (format "%s/?query=%s" graphql-url (url-encode-url query))))
+        (url (format "%s?query=%s" graphql-url (url-encode-url query))))
     (with-current-buffer (url-retrieve-synchronously url t)
       (goto-char (point-min))
       (search-forward "\n\n")


### PR DESCRIPTION
Some graphql endpoints only expose example.com/graphql,
not example.com/graphql/