### PR TITLE
add keywords only completion

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -116,8 +116,6 @@ response from the server."
     (setq graphql-url url)
     nil))
 
-
-
 (defvar graphql-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") 'graphql-send-query)
@@ -147,9 +145,24 @@ response from the server."
     (when (< position indent-pos)
       (goto-char indent-pos))))
 
+(defvar graphql-keywords
+        '("type" "input" "interface" "fragment" "query" "enum" "mutation" "subscription"
+	"Int" "Float" "String" "Boolean" "ID"
+	"true" "false" "null"
+       ))
+
+(defun graphql-completion-at-point ()
+  "This is the function to be used for the hook `completion-at-point-functions'."
+  (interactive)
+  (let* (
+         (bds (bounds-of-thing-at-point 'symbol))
+         (start (car bds))
+         (end (cdr bds)))
+    (list start end graphql-keywords . nil )))
+
 
 (defvar graphql-definition-regex
-  (concat "\\(" (regexp-opt '("type" "input" "interface" "fragment" "query" "enum")) "\\)"
+  (concat "\\(" (regexp-opt graphql-keywords) "\\)"
           "[[:space:]]+\\(\\_<.+?\\_>\\)"))
 
 (defvar graphql-builtin-types
@@ -235,7 +248,8 @@ response from the server."
           nil
           nil))
   (setq imenu-generic-expression
-        `((nil ,graphql-definition-regex 2))))
+        `((nil ,graphql-definition-regex 2)))
+  (add-hook 'completion-at-point-functions 'graphql-completion-at-point nil 'local))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.graphql\\'" . graphql-mode))

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -162,7 +162,7 @@ response from the server."
 
 
 (defvar graphql-definition-regex
-  (concat "\\(" (regexp-opt graphql-keywords) "\\)"
+  (concat "\\(" (regexp-opt '("type" "input" "interface" "fragment" "query" "enum")) "\\)"
           "[[:space:]]+\\(\\_<.+?\\_>\\)"))
 
 (defvar graphql-builtin-types


### PR DESCRIPTION
1. add keywords only using `completion-at-point` 
1. type `M-C-i` to invoke `completion-at-point`, say `in|` (see picture below)

<img width="1444" alt="screen shot 2017-09-27 at 10 07 00 pm" src="https://user-images.githubusercontent.com/13225610/30950258-9cb0196e-a3d0-11e7-852d-417ca7145252.png">

