### PR TITLE
rebased branch 'mutiple-queries' onto branch 'next'

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -127,12 +127,15 @@ of the variables used in the query."
     (if (not (equal start end))
 	(buffer-substring-no-properties start end)
       (save-excursion
-	(let ((line (thing-at-point 'line t)))
+	(let ((saved-point (point))
+	      (line (thing-at-point 'line t)))
 	  (when (string-match-p (regexp-quote "}") line)
-	    (search-backward "}"))
+	    (search-backward "}" (beginning-of-line)))
 	  (when (string-match-p (regexp-quote "{") line)
-	    (search-forward "{"))
-	  (graphql-current-query))))))
+	    (search-forward "{" (end-of-line)))
+	  (if (= (point) saved-point)
+	      nil
+	    (graphql-current-query)))))))
 
 (defun graphql-current-operation ()
   "Return the name of the current graphql query."

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -22,7 +22,7 @@
 ;;; Commentary:
 
 ;; This package implements a major mode to edit GraphQL schemas and
-;; query.  The basic functionality includes:
+;; query. The basic functionality includes:
 ;;
 ;;    - Syntax highlight
 ;;    - Automatic indentation
@@ -188,14 +188,16 @@ of the variables used in the query."
 (defvar graphql-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") 'graphql-send-query)
-    map))
+    map)
+  "Key binding for GraphQL mode.")
 
 (defvar graphql-mode-syntax-table
   (let ((st (make-syntax-table)))
     (modify-syntax-entry ?\# "<" st)
     (modify-syntax-entry ?\n ">" st)
     (modify-syntax-entry ?\$ "'" st)
-    st))
+    st)
+  "Syntax table for GraphQL mode.")
 
 
 (defun graphql-indent-line ()
@@ -292,7 +294,8 @@ of the variables used in the query."
 
     ;; Field parameters
     (graphql--field-parameter-matcher
-     (1 font-lock-variable-name-face))))
+     (1 font-lock-variable-name-face)))
+  "Font Lock keywords.")
 
 
 ;;;###autoload

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -124,7 +124,15 @@ of the variables used in the query."
          (save-excursion
            (graphql-end-of-query)
            (point))))
-    (buffer-substring-no-properties start end)))
+    (if (not (equal start end))
+	(buffer-substring-no-properties start end)
+      (save-excursion
+	(let ((line (thing-at-point 'line t)))
+	  (when (string-match-p (regexp-quote "}") line)
+	    (beginning-of-line))
+	  (when (string-match-p (regexp-quote "{") line)
+	    (end-of-line))
+	  (graphql-current-query))))))
 
 (defun graphql-current-operation ()
   "Return the name of the current graphql query."

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -129,9 +129,9 @@ of the variables used in the query."
       (save-excursion
 	(let ((line (thing-at-point 'line t)))
 	  (when (string-match-p (regexp-quote "}") line)
-	    (beginning-of-line))
+	    (search-backward "}"))
 	  (when (string-match-p (regexp-quote "{") line)
-	    (end-of-line))
+	    (search-forward "{"))
 	  (graphql-current-query))))))
 
 (defun graphql-current-operation ()


### PR DESCRIPTION
1. add `graphql-encode-json`, which takes queries, variables, and operation.
    this `graphql-encode-json` is used by both  
    `graphql--query` and `graphql-post-request`
