### PR TITLE
Avoid double-encoding variables in JSON

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -187,7 +187,7 @@ Please install it and try again."))
            (file-exists-p filename))
       (condition-case nil
           (progn (get-buffer-create (find-file-noselect filename))
-                 (json-encode (json-read-file filename)))
+                 (json-read-file filename))
         (error nil))
     nil))
 


### PR DESCRIPTION
Previous behaviour produced requests like:

`{"variables": "{\"id\": 42}", "query": ...}`

i.e. variables was stringified JSON within the JSON object. This isn't
supported by all GraphQL server implementations, so this change
produces the structure:

`{"variables": {"id": 42}, "query": ...}`

which is more widely supported.