### PR TITLE
Don't use temp buffer, as it breaks local variables

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -94,8 +94,7 @@ of the variables used in the query."
   ;; Note that we need to get the value of graphql-url in the current
   ;; before before we switch to the temporary one.
   (let ((url graphql-url))
-    (with-temp-buffer
-      (graphql-post-request url query operation variables))))
+    (graphql-post-request url query operation variables)))
 
 (declare-function request "request")
 (declare-function request-response-data "request")


### PR DESCRIPTION
In the previous implementation, setting `graphql-extra-headers` as a
local variable didn't work because the variable was used inside
`graphql-post-request` which was called inside a temp buffer.

Removing the temp buffer solves this issue.

Maybe the temp buffer was there for a specific reason, and shouldn't be removed. Let me know if that's the case.
