### PR TITLE
Don't send operationName when operation is an empty string

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -77,7 +77,7 @@
   "Put together a json like object with QUERY, OPERATION, and VARIABLES."
   (let* ((body '()))
     (push (cons 'query query) body)
-    (when operation
+    (when (and operation (not (string= operation "")))
       (push (cons 'operationName operation) body))
     (when variables
       (push (cons 'variables variables) body))


### PR DESCRIPTION
This happen, for instance, in the query below. That would cause
"operationName": "" to be sent in the request json, which leads to
errors in the backend.

    query {
      repositoryOwner(login: "Malabarba") {
        repositories(first: 100, isFork: false) {
          totalCount
          nodes { name }
        }
      }
    }