### PR TITLE
Also insert response headers in the buffer (with comment face)

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -110,20 +110,18 @@ VARIABLES list of variables for query operation"
       (error "graphql-post-request needs the request package.  \
 Please install it and try again."))
   (let* ((body (graphql-encode-json query operation variables))
-         (headers (append '(("Content-Type" . "application/json")) graphql-extra-headers))
-         (response (request
-                    url
-                    :type "POST"
-                    :data body
-                    :headers headers
-                    :parser 'json-read
-                    :sync t
-                    :complete (lambda (&rest _)
-                                (message "%s" (if (string-equal "" operation)
-                                                  url
-                                                (format "%s?operationName=%s"
-                                                        url operation)))))))
-    (json-encode (request-response-data response))))
+         (headers (append '(("Content-Type" . "application/json")) graphql-extra-headers)))
+    (request url
+             :type "POST"
+             :data body
+             :headers headers
+             :parser 'json-read
+             :sync t
+             :complete (lambda (&rest _)
+                         (message "%s" (if (string-equal "" operation)
+                                           url
+                                         (format "%s?operationName=%s"
+                                                 url operation)))))))
 
 (defun graphql-beginning-of-query ()
   "Move the point to the beginning of the current query."
@@ -213,8 +211,13 @@ Please install it and try again."))
          ;;
          ;; (when (fboundp 'json-mode)
          ;;   (json-mode))
-         (insert response)
-         (json-pretty-print-buffer))))
+         (insert (json-encode (request-response-data response)))
+         (json-pretty-print-buffer)
+         (goto-char (point-max))
+         (insert "\n\n"
+                 (propertize (request-response--raw-header response)
+                             'face 'font-lock-comment-face
+                             'font-lock-face 'font-lock-comment-face)))))
     ;; If the query was successful, then save the value of graphql-url
     ;; in the current buffer (instead of the introduced local
     ;; binding).


### PR DESCRIPTION
This makes it so that the response http headers are printed after the response body

For instance, instead of this:

```
{
  "errors": [
    {
      "status": 403,
      "message": "Access denied, invalid token"
    }
  ]
}
```

You'll get this:

```
{
  "errors": [
    {
      "status": 403,
      "message": "Access denied, invalid token"
    }
  ]
}

HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: no-referrer-when-downgrade
Content-Type: application/json; charset=utf-8
ETag: W/"f31e12405e0c44da9fcc1f92e4153f3c"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: 026e779b-5f34-46ab-a3a8-17ba0509e1bd
X-Runtime: 0.068260
Vary: Origin
Transfer-Encoding: chunked
```