### PR TITLE
added support for 'extend', 'scalar' and 'union' keywords

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -261,7 +261,8 @@ Please install it and try again."))
   '("type" "input" "interface" "fragment"
     "query" "enum" "mutation" "subscription"
     "Int" "Float" "String" "Boolean" "ID"
-    "true" "false" "null"))
+    "true" "false" "null" "extend"
+    "scalar" "union"))
 
 (defun graphql-completion-at-point ()
   "Return the list of candidates for completion.
@@ -274,8 +275,9 @@ This is the function to be used for the hook `completion-at-point-functions'."
 
 (defvar graphql-definition-regex
   (concat "\\(" (regexp-opt '("type" "input" "interface" "fragment" "query"
-                  "mutation" "subscription" "enum")) "\\)"
-          "[[:space:]]+\\(\\_<.+?\\_>\\)")
+                              "mutation" "subscription" "enum" "extend"
+                              "scalar" "union")) "\\)"
+                              "[[:space:]]+\\(\\_<.+?\\_>\\)")
   "Keyword Regular Expressions.")
 
 (defvar graphql-builtin-types


### PR DESCRIPTION
Some keywords such as `extend`, `scalar` and `union` appear to be missing from this package, which causes syntax highlighting to not look right.