### PR TITLE
declare request-response--raw-header function

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -98,6 +98,7 @@ of the variables used in the query."
 
 (declare-function request "request")
 (declare-function request-response-data "request")
+(declare-function request-response--raw-header "request")
 
 (defun graphql-post-request (url query &optional operation variables)
   "Make post request to graphql server with url and body.


### PR DESCRIPTION
Hi! Thanks to deverop such a great package!

I found below byte-compile warnings and fix it.

```
graphql-mode.el:374:1:Warning: the function ‘request-response--raw-header’
    is not known to be defined.
```