### PR TITLE
Org-babel GraphQL execution backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,92 @@ extension will be loaded with this mode.
 
 You can optionally install `json-mode`, and it will be enabled in the
 buffer that contains the response from a GraphQL service.
+
+## Org-Babel integration
+`graphql-mode` includes an integration with [Babel](https://orgmode.org/worg/org-contrib/babel/intro.html), org-mode's literate programming environment. You can enable it by loading `ob-graphql`:
+
+``` emacs-lisp
+(require 'ob-graphql)
+```
+
+Once it is loaded, you can evaluate `graphql` source blocks. The URL of the GraphQL server should be given by the `:url` header parameter:
+
+``` org
+#+BEGIN_SRC graphql :url https://countries.trevorblades.com/
+  query GetContinents {
+      continent(code: "AF") {
+          name
+	  code
+      }
+  }
+#+END_SRC
+
+#+RESULTS:
+: {
+:   "data": {
+:     "continent": {
+:       "name": "Africa",
+:       "code": "AF"
+:     }
+:   }
+: }
+```
+
+Variables can be passed into the source block from other source/example blocks via the `:variables` header parameter. The parameter should be the name of the variables source block, which should evaluate to the JSON body of the variables to pass into the query:
+
+``` org
+#+NAME: my-variables
+#+begin_example
+  {
+      "continentCode": "AF"
+  }
+#+end_example
+
+#+BEGIN_SRC graphql :url https://countries.trevorblades.com/ :variables my-variables
+  query GetContinents($continentCode: String!) {
+      continent(code: $continentCode) {
+          name
+	  code
+      }
+  }
+#+END_SRC
+
+#+RESULTS:
+: {
+:   "data": {
+:     "continent": {
+:       "name": "Africa",
+:       "code": "AF"
+:     }
+:   }
+: }
+
+```
+
+Additional headers, such as an `Authorization` header, can be passed into the query via the `:headers` header parameter. This parameter should be the name of another source block that evaluates to an alist of header names to header values:
+
+``` org
+#+NAME: my-headers
+#+BEGIN_SRC emacs-lisp
+  '(("Authorization" . "Bearer my-secret-token"))
+#+END_SRC
+
+#+BEGIN_SRC graphql :url https://countries.trevorblades.com/ :headers my-headers
+  query GetContinents {
+      continent(code: "AF") {
+          name
+	  code
+      }
+  }
+#+END_SRC
+
+#+RESULTS:
+: {
+:   "data": {
+:     "continent": {
+:       "name": "Africa",
+:       "code": "AF"
+:     }
+:   }
+: }
+```

--- a/ob-graphql.el
+++ b/ob-graphql.el
@@ -1,5 +1,6 @@
 (require 'graphql-mode)
 
+;;;###autoload
 (defun org-babel-execute:graphql (body params)
   (let* ((url (cdr (assq :url params)))
 	 (op-name (cdr (assq :operation params)))

--- a/ob-graphql.el
+++ b/ob-graphql.el
@@ -1,4 +1,7 @@
 (require 'graphql-mode)
+(require 'json)
+(require 'ob-ref)
+(require 'request)
 
 ;;;###autoload
 (defun org-babel-execute:graphql (body params)

--- a/ob-graphql.el
+++ b/ob-graphql.el
@@ -1,0 +1,20 @@
+(require 'graphql-mode)
+
+(defun org-babel-execute:graphql (body params)
+  (let* ((url (cdr (assq :url params)))
+	 (op-name (cdr (assq :operation params)))
+	 (variables (cdr (assq :variables params)))
+	 (variables-val (when variables
+			  (json-read-from-string (org-babel-ref-resolve variables))))
+	 (headers (cdr (assq :headers params)))
+	 (graphql-extra-headers
+	  (when headers (org-babel-ref-resolve headers)))
+         (response (if variables-val
+		       (graphql-post-request url body op-name variables-val)
+		     (graphql-post-request url body op-name))))
+    (with-temp-buffer
+      (insert (json-encode (request-response-data response)))
+      (json-pretty-print-buffer)
+      (buffer-substring (point-min) (point-max)))))
+
+(provide 'ob-graphql)


### PR DESCRIPTION
This adds a new library, `ob-graphql`, that provides an org-mode [Babel](https://orgmode.org/worg/org-contrib/babel/intro.html) execution backend for GraphQL snippets. Usage instructions are the updated README provided in the PR.

This seems like a nice addition to `graphql-mode` because it allows us to add a GraphQL snippet to an Org document, edit it inline via GraphQL mode, then evaluate it in the context of the Org document, pipe its results to other source blocks in the document, or export those results to another document format.