### PR TITLE
Headers buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ extension will be loaded with this mode.
 
 You can optionally install `json-mode`, and it will be enabled in the
 buffer that contains the response from a GraphQL service.
+
+## Querying Endpoints
+
+To send a query to a server, you will first need the
+[`request`](https://github.com/tkf/emacs-request) package. Then use
+`graphql-send-query` (`C-c C-c`) to send a query.
+
+If you have a `.graphqlconfig` file, you can select an endpoint configuration
+with `graphql-select-endpoint` (`C-c C-l`).
+
+To send additional headers for a request, `graphql-extra-headers` must be
+set. It is automatically set by `graphql-select-endpoint`, or you can edit its
+value using JSON with `graphql-edit-headers` (`C-C e h`).

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ with `graphql-select-endpoint` (`C-c C-l`).
 
 To send additional headers for a request, `graphql-extra-headers` must be
 set. It is automatically set by `graphql-select-endpoint`, or you can edit its
-value using JSON with `graphql-edit-headers` (`C-C e h`).
+value using JSON with `graphql-edit-headers` (`C-c e h`).

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -398,6 +398,8 @@ Open a buffer to edit `graphql-extra-headers'.  The contents of this
 buffer take precedence over the setting in `graphql-extra-headers'
 when sending a request."
   (interactive)
+  (unless (equal major-mode 'graphql-mode)
+    (error "Not in graphql-mode, cannot edit headers"))
   (let ((extra-headers-buffer
          (concat "*Graphql Headers for " (buffer-name) "*")))
     (pop-to-buffer extra-headers-buffer)

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -421,8 +421,8 @@ when sending a request."
   "Accept buffer contents and write to `graphql-extra-headers'."
   (interactive)
   (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
-  (message "TODO: save to graphql-extra-headers")
-  (graphql-edit-buffers--kill-pop-up-buffer))
+  (setq graphql-extra-headers (json-read-from-string (buffer-string)))
+  (graphql-edit-headers--kill-pop-up-buffer))
 
 (defun graphql-edit-headers-abort ()
   "Kill current headers buffer and return to graphql file."

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -403,7 +403,7 @@ when sending a request."
   (let ((extra-headers-buffer
          (concat "*Graphql Headers for " (buffer-name) "*")))
     (pop-to-buffer extra-headers-buffer)
-    (if graphql-extra-headers
+    (if (and (string-empty-p (buffer-string)) graphql-extra-headers)
         (progn
           (insert (json-serialize graphql-extra-headers))
           (json-pretty-print (point-min) (point-max))

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -398,7 +398,7 @@ buffer take precedence over the setting in `graphql-extra-headers'
 when sending a request."
   (interactive)
   (let ((extra-headers-buffer
-         (concat "*Graphql Headers for " (buffer-name (buffer-base-buffer)) "*")))
+         (concat "*Graphql Headers for " (buffer-name) "*")))
     (pop-to-buffer extra-headers-buffer)
     (if graphql-extra-headers
         (progn

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -440,7 +440,7 @@ interactively with `\\[graphql-edit-headers]'."
             (define-key map (kbd "C-c C-k") 'graphql-edit-headers-abort)
             map)
   (setq header-line-format (substitute-command-keys "Edit GraphQL query headers.  Save with \
-`\\[graphql-edit-headers-save]' or abort with `\\[graphql-edit-headers-abort]'")))
+`\\[graphql-edit-headers-accept]' or abort with `\\[graphql-edit-headers-abort]'")))
 
 
 ;;;###autoload

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -406,27 +406,34 @@ when sending a request."
     (pop-to-buffer extra-headers-buffer)
     (when (fboundp 'json-mode)
       (json-mode))
-    (graphql-edit-headers-mode)))
+    (graphql-edit-headers-mode))
+  (message "TODO: populate with graphql extra headers content"))
 
 (defun graphql-edit-headers-buffer-p ()
   "Non-nil when current buffer is a header editing buffer."
   (bound-and-true-p graphql-edit-headers-mode))
 
-(defun graphql-edit-headers-save ()
-  "TODO."
-  (interactive)
-  (message "TODO"))
-
-(defun graphql-edit-headers-abort ()
-  "Kill current headers buffer and return to graphql file."
-  (interactive)
-  (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
+(defun graphql-edit-headers--kill-pop-up-buffer ()
+  "Kill transient buffer and restore window configuration."
   (set-buffer-modified-p nil)
   (kill-buffer (current-buffer))
   (when graphql-edit-headers--saved-temporary-window-config
     (unwind-protect
         (set-window-configuration graphql-edit-headers--saved-temporary-window-config)
       (setq graphql-edit-headers--saved-temporary-window-config nil))))
+
+(defun graphql-edit-headers-accept ()
+  "Accept buffer contents and write to `graphql-extra-headers'."
+  (interactive)
+  (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
+  (message "TODO: save to graphql-extra-headers")
+  (graphql-edit-buffers--kill-pop-up-buffer))
+
+(defun graphql-edit-headers-abort ()
+  "Kill current headers buffer and return to graphql file."
+  (interactive)
+  (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
+  (graphql-edit-headers--kill-pop-up-buffer))
 
 (define-minor-mode graphql-edit-headers-mode
   "Minor mode for editing graphql extra headers.
@@ -435,7 +442,7 @@ This minor mode is turned on when you edit GraphQL headers
 interactively with `\\[graphql-edit-headers]'."
   :lighter " GQL Hdr"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-c C-c") 'graphql-edit-headers-save)
+            (define-key map (kbd "C-c C-c") 'graphql-edit-headers-accept)
             (define-key map (kbd "C-c C-k") 'graphql-edit-headers-abort)
             map)
   (setq header-line-format (substitute-command-keys "Edit GraphQL query headers.  Save with \

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -400,10 +400,14 @@ when sending a request."
   (let ((extra-headers-buffer
          (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
     (pop-to-buffer extra-headers-buffer)
+    (if graphql-extra-headers
+        (progn
+          (insert (json-serialize graphql-extra-headers))
+          (json-pretty-print (point-min) (point-max))
+          (goto-char (point-min))))
     (when (fboundp 'json-mode)
       (json-mode))
-    (graphql-edit-headers-mode))
-  (message "TODO: populate with graphql extra headers content"))
+    (graphql-edit-headers-mode)))
 
 (defun graphql-edit-headers-buffer-p ()
   "Non-nil when current buffer is a header editing buffer."

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -405,7 +405,7 @@ when sending a request."
     (pop-to-buffer extra-headers-buffer)
     (if (and (string-empty-p (buffer-string)) graphql-extra-headers)
         (progn
-          (insert (json-serialize graphql-extra-headers))
+          (insert (json-encode graphql-extra-headers))
           (json-pretty-print (point-min) (point-max))
           (goto-char (point-min))))
     (when (fboundp 'json-mode)

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -398,7 +398,7 @@ buffer take precedence over the setting in `graphql-extra-headers'
 when sending a request."
   (interactive)
   (let ((extra-headers-buffer
-         (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
+         (concat "*Graphql Headers for " (buffer-name (buffer-base-buffer)) "*")))
     (pop-to-buffer extra-headers-buffer)
     (if graphql-extra-headers
         (progn

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -261,6 +261,7 @@ Please install it and try again."))
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") 'graphql-send-query)
     (define-key map (kbd "C-c C-l") 'graphql-select-endpoint)
+    (define-key map (kbd "C-c e h") 'graphql-edit-headers)
     map)
   "Key binding for GraphQL mode.")
 

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -153,6 +153,43 @@ Please install it and try again."))
                                          (format "%s?operationName=%s"
                                                  url operation)))))))
 
+(defun graphql-edit-headers ()
+  "Edit graphql request headers interactively in a dedicated buffer.
+
+Open a buffer to edit `graphql-extra-headers'.  The contents of this
+buffer take precedence over the setting in `graphql-extra-headers'
+when sending a request."
+  (interactive)
+  (let* ((extra-headers-buffer
+          (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
+    (pop-to-buffer extra-headers-buffer)
+    (graphql-edit-headers-mode)
+    (when (fboundp 'json-mode)
+      (json-mode))))
+
+(defun graphql-edit-headers-save ()
+  "TODO."
+  (interactive)
+  (message "TODO"))
+
+(defun graphql-edit-headers-abort ()
+  "TODO."
+  (interactive)
+  (message "TODO"))
+
+(define-minor-mode graphql-edit-headers-mode
+  "Minor mode for editing graphql extra headers.
+\\<graphql-mode-map>
+This minor mode is turned on when you edit GraphQL headers
+interactively with `\\[graphql-edit-headers]'."
+  :lighter " GQL Hdr"
+  :keymap (let ((map (make-sparse-keymap)))
+            (define-key map (kbd "C-c C-c") 'graphql-edit-headers-save)
+            (define-key map (kbd "C-c C-k") 'graphql-edit-headers-abort)
+            map)
+  (setq header-line-format (substitute-command-keys "Edit GraphQL query headers.  Save with \
+`\\[graphql-edit-headers-save]' or abort with `\\[graphql-edit-headers-abort]'")))
+
 (defun graphql-beginning-of-query ()
   "Move the point to the beginning of the current query."
   (interactive)

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -413,22 +413,18 @@ when sending a request."
   "Non-nil when current buffer is a header editing buffer."
   (bound-and-true-p graphql-edit-headers-mode))
 
-(defun graphql-edit-headers--kill-pop-up-buffer ()
-  "Kill transient buffer and restore window configuration."
-  (quit-window 'kill-buffer))
-
 (defun graphql-edit-headers-accept ()
   "Accept buffer contents and write to `graphql-extra-headers'."
   (interactive)
   (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
   (setq graphql-extra-headers (json-read-from-string (buffer-string)))
-  (graphql-edit-headers--kill-pop-up-buffer))
+  (quit-window 'kill-buffer))
 
 (defun graphql-edit-headers-abort ()
   "Kill current headers buffer and return to graphql file."
   (interactive)
   (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
-  (graphql-edit-headers--kill-pop-up-buffer))
+  (quit-window 'kill-buffer))
 
 (define-minor-mode graphql-edit-headers-mode
   "Minor mode for editing graphql extra headers.

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -153,57 +153,6 @@ Please install it and try again."))
                                          (format "%s?operationName=%s"
                                                  url operation)))))))
 
-(defvar-local graphql-edit-headers--saved-temporary-window-config nil)
-(put 'graphql-edit-headers--saved-temporary-window-config 'permanent-local t)
-
-(defun graphql-edit-headers ()
-  "Edit graphql request headers interactively in a dedicated buffer.
-
-Open a buffer to edit `graphql-extra-headers'.  The contents of this
-buffer take precedence over the setting in `graphql-extra-headers'
-when sending a request."
-  (interactive)
-  (setq graphql-edit-headers--saved-temporary-window-config (current-window-configuration))
-  (let ((extra-headers-buffer
-         (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
-    (pop-to-buffer extra-headers-buffer)
-    (when (fboundp 'json-mode)
-      (json-mode))
-    (graphql-edit-headers-mode)))
-
-(defun graphql-edit-headers-buffer-p ()
-  "Non-nil when current buffer is a header editing buffer."
-  (bound-and-true-p graphql-edit-headers-mode))
-
-(defun graphql-edit-headers-save ()
-  "TODO."
-  (interactive)
-  (message "TODO"))
-
-(defun graphql-edit-headers-abort ()
-  "Kill current headers buffer and return to graphql file."
-  (interactive)
-  (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
-  (set-buffer-modified-p nil)
-  (kill-buffer (current-buffer))
-  (when graphql-edit-headers--saved-temporary-window-config
-    (unwind-protect
-        (set-window-configuration graphql-edit-headers--saved-temporary-window-config)
-      (setq graphql-edit-headers--saved-temporary-window-config nil))))
-
-(define-minor-mode graphql-edit-headers-mode
-  "Minor mode for editing graphql extra headers.
-\\<graphql-mode-map>
-This minor mode is turned on when you edit GraphQL headers
-interactively with `\\[graphql-edit-headers]'."
-  :lighter " GQL Hdr"
-  :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-c C-c") 'graphql-edit-headers-save)
-            (define-key map (kbd "C-c C-k") 'graphql-edit-headers-abort)
-            map)
-  (setq header-line-format (substitute-command-keys "Edit GraphQL query headers.  Save with \
-`\\[graphql-edit-headers-save]' or abort with `\\[graphql-edit-headers-abort]'")))
-
 (defun graphql-beginning-of-query ()
   "Move the point to the beginning of the current query."
   (interactive)
@@ -438,6 +387,59 @@ This is the function to be used for the hook `completion-at-point-functions'."
     (graphql--field-parameter-matcher
      (1 font-lock-variable-name-face)))
   "Font Lock keywords.")
+
+;;; Edit headers functionality:
+
+(defvar-local graphql-edit-headers--saved-temporary-window-config nil)
+(put 'graphql-edit-headers--saved-temporary-window-config 'permanent-local t)
+
+(defun graphql-edit-headers ()
+  "Edit graphql request headers interactively in a dedicated buffer.
+
+Open a buffer to edit `graphql-extra-headers'.  The contents of this
+buffer take precedence over the setting in `graphql-extra-headers'
+when sending a request."
+  (interactive)
+  (setq graphql-edit-headers--saved-temporary-window-config (current-window-configuration))
+  (let ((extra-headers-buffer
+         (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
+    (pop-to-buffer extra-headers-buffer)
+    (when (fboundp 'json-mode)
+      (json-mode))
+    (graphql-edit-headers-mode)))
+
+(defun graphql-edit-headers-buffer-p ()
+  "Non-nil when current buffer is a header editing buffer."
+  (bound-and-true-p graphql-edit-headers-mode))
+
+(defun graphql-edit-headers-save ()
+  "TODO."
+  (interactive)
+  (message "TODO"))
+
+(defun graphql-edit-headers-abort ()
+  "Kill current headers buffer and return to graphql file."
+  (interactive)
+  (unless (graphql-edit-headers-buffer-p) (error "Not in a GraphQL headers buffer"))
+  (set-buffer-modified-p nil)
+  (kill-buffer (current-buffer))
+  (when graphql-edit-headers--saved-temporary-window-config
+    (unwind-protect
+        (set-window-configuration graphql-edit-headers--saved-temporary-window-config)
+      (setq graphql-edit-headers--saved-temporary-window-config nil))))
+
+(define-minor-mode graphql-edit-headers-mode
+  "Minor mode for editing graphql extra headers.
+\\<graphql-mode-map>
+This minor mode is turned on when you edit GraphQL headers
+interactively with `\\[graphql-edit-headers]'."
+  :lighter " GQL Hdr"
+  :keymap (let ((map (make-sparse-keymap)))
+            (define-key map (kbd "C-c C-c") 'graphql-edit-headers-save)
+            (define-key map (kbd "C-c C-k") 'graphql-edit-headers-abort)
+            map)
+  (setq header-line-format (substitute-command-keys "Edit GraphQL query headers.  Save with \
+`\\[graphql-edit-headers-save]' or abort with `\\[graphql-edit-headers-abort]'")))
 
 
 ;;;###autoload

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -390,9 +390,6 @@ This is the function to be used for the hook `completion-at-point-functions'."
 
 ;;; Edit headers functionality:
 
-(defvar-local graphql-edit-headers--saved-temporary-window-config nil)
-(put 'graphql-edit-headers--saved-temporary-window-config 'permanent-local t)
-
 (defun graphql-edit-headers ()
   "Edit graphql request headers interactively in a dedicated buffer.
 
@@ -400,7 +397,6 @@ Open a buffer to edit `graphql-extra-headers'.  The contents of this
 buffer take precedence over the setting in `graphql-extra-headers'
 when sending a request."
   (interactive)
-  (setq graphql-edit-headers--saved-temporary-window-config (current-window-configuration))
   (let ((extra-headers-buffer
          (concat "*Graphql Headers for " (buffer-file-name (buffer-base-buffer)) "*")))
     (pop-to-buffer extra-headers-buffer)
@@ -415,12 +411,7 @@ when sending a request."
 
 (defun graphql-edit-headers--kill-pop-up-buffer ()
   "Kill transient buffer and restore window configuration."
-  (set-buffer-modified-p nil)
-  (kill-buffer (current-buffer))
-  (when graphql-edit-headers--saved-temporary-window-config
-    (unwind-protect
-        (set-window-configuration graphql-edit-headers--saved-temporary-window-config)
-      (setq graphql-edit-headers--saved-temporary-window-config nil))))
+  (quit-window 'kill-buffer))
 
 (defun graphql-edit-headers-accept ()
   "Accept buffer contents and write to `graphql-extra-headers'."


### PR DESCRIPTION
This is a rough draft of the edit headers functionality (#41) for UX testing. The buffer can be opened with `graphql-edit-headers`, which I have not bound yet. Some things I'd like to still explore:

- [x] Should we check for `.graphqlconfig` and do a completing read on the endpoints *before* opening the buffer? Then add the content for the headers from the endpoint.
- [x] Should the *buffer contents* override `graphql-extra-headers` when the buffer is *currently open*? This may be confusing if the buffer is currently invisible.
- [x] I'd like to name the buffer somewhat better, using the parent buffer's unique name. I'll look into that.
- [x] Reuse any existing buffer of the same name? I.e. if the user navigates away from the transient buffer, then goes back to the graphql file and uses `graphql-edit-headers` again?
- [x] What's a good default keybinding? I use Evil, so I have no idea how Emacs-world comes up with key bindings :laughing: 
- [x] Needs documentation, at least in the readme

All the good bits here are directly nicked from `org-src.el` :stuck_out_tongue_closed_eyes:

I don't think we need completion. `Content-Type` is set, so we don't need MIME-types. The common header names are not terribly interesting. I mean, it's almost always going to be some variant of `Authorization` plus whatever else your endpoint requires, which may be pretty arbitrary.