### PR TITLE
Prepare graphql-mode for inclusion in NonGNU ELPA

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -6,6 +6,7 @@
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "24.3"))
 ;; Homepage: https://github.com/davazp/graphql-mode
+;; Version: 1.0.0
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hello,

as part of an initiative to add more language major modes to [NonGNU ELPA](https://elpa.nongnu.org), I would like to add graphql-mode to the archive. Compared to MELPA, ELPA requires a version tag to be maintained and updated for each release. I have added one and set it to 1.0.0, assuming stability as no major changes have been made over the last year. If you would want a different version number, please say so before merging the request.

Furthermore, I have made the dependency on request.el more explicit, I hope that is ok too.