### PR TITLE
Fix Parameters on the Same line not Fontified

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -343,7 +343,7 @@ This is the function to be used for the hook `completion-at-point-functions'."
        ;; the search can continue.
        ((graphql--in-arguments-p)
         (let* ((end (save-excursion (up-list) (point)))
-               (match (search-forward-regexp "\\(\\_<.+?\\_>\\):" end t)))
+               (match (search-forward-regexp "\\(\\_<[a-zA-Z0-9_-]+?\\_>\\):" end t)))
           (if match
               ;; unless we are inside a string or comment
               (let ((state (syntax-ppss)))

--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -343,7 +343,7 @@ This is the function to be used for the hook `completion-at-point-functions'."
        ;; the search can continue.
        ((graphql--in-arguments-p)
         (let* ((end (save-excursion (up-list) (point)))
-               (match (search-forward-regexp "\\(\\_<[a-zA-Z0-9_-]+?\\_>\\):" end t)))
+               (match (search-forward-regexp "\\(\\_<[_A-Za-z][_0-9A-Za-z]*?\\_>\\):" end t)))
           (if match
               ;; unless we are inside a string or comment
               (let ((state (syntax-ppss)))


### PR DESCRIPTION
Hi! I noticed that if I put field parameters on the same line, they are not fontified beyond the first occurrence:
![gql-fontlock-before](https://user-images.githubusercontent.com/17688577/143655521-272ecec1-98b8-4c42-b376-7be75d785093.png)

After some debugging with font lock studio I tweaked the regex a little and:
![gql-fontlock-after](https://user-images.githubusercontent.com/17688577/143655554-1b2b58d7-c13c-444e-8d67-7650c4ecd8c9.png)

Let me know what you think.