### PR TITLE
fix: allow edit headers in graphql-ts-mode

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: David Vazquez Pua <davazp@gmail.com>
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Homepage: https://github.com/davazp/graphql-mode
 ;; Version: 1.0.0
 
@@ -73,7 +73,7 @@
 (defcustom graphql-extra-headers '()
   "Headers to send to the graphql endpoint."
   :tag "GraphQL"
-  :type 'list
+  :type '(repeat sexp)
   :group 'graphql)
 
 (defun graphql-locate-config (dir)
@@ -437,7 +437,7 @@ Open a buffer to edit `graphql-extra-headers'.  The contents of this
 buffer take precedence over the setting in `graphql-extra-headers'
 when sending a request."
   (interactive)
-  (unless (equal major-mode 'graphql-mode)
+  (unless (memq major-mode '(graphql-mode graphql-ts-mode))
     (error "Not in graphql-mode, cannot edit headers"))
   (let ((extra-headers-buffer-name
          (concat "*Graphql Headers for " (buffer-name) "*"))


### PR DESCRIPTION
This change just accepts `graphql-ts-mode` in addition to `graphql-mode` for
editing headers.

Also, a couple minor meta fixes for `defcustom` list `:type` and update required emacs version
to "25.1" to cover `let-alist` and `if-let`.