### PR TITLE
Fix point-at-bol byte comp warning

### DIFF
--- a/graphql-mode.el
+++ b/graphql-mode.el
@@ -322,7 +322,7 @@ With \\[universal-argument] PROMPT, prompt for
       (setq column (current-column)))
 
     (save-excursion
-      (let ((level (car (syntax-ppss (point-at-bol)))))
+      (let ((level (car (syntax-ppss (line-beginning-position)))))
 
         ;; Handle closing pairs
         (when (looking-at "\\s-*\\s)")


### PR DESCRIPTION
Hi!  This PR fixes the byte comp warning I get with `29.1`:

```
graphql-mode.el:288:39: Warning: ‘point-at-bol’ is an obsolete function (as of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
```

I believe the fix should be compatible with Emacs 25.

Thanks!